### PR TITLE
adding p99.9 option to runner and logic to report to include and calculate p99.9.

### DIFF
--- a/printer/influx.go
+++ b/printer/influx.go
@@ -180,6 +180,14 @@ func (rp *ReportPrinter) getInfluxFields() string {
 			if v.Percentage == 95 {
 				s = append(s, fmt.Sprintf("p95=%v", v.Latency.Nanoseconds()))
 			}
+
+			if v.Percentage == 99 {
+				s = append(s, fmt.Sprintf("p99=%v", v.Latency.Nanoseconds()))
+			}
+
+			if v.Percentage == 99.9 {
+				s = append(s, fmt.Sprintf("p99_9=%v", v.Latency.Nanoseconds()))
+			}
 		}
 	}
 

--- a/printer/template.go
+++ b/printer/template.go
@@ -471,6 +471,18 @@ duration (ms),status,error{{ range $i, $v := .Details }}
 			  tension: 0.3,
 			  pointRadius: 0,
 			  yAxisID: "y2"
+			},
+			{{ end }}
+			{{ if .P99_9 }}
+			{
+			  label: 'P99.9',
+			  data: aggData.map((item) => ({ x: item.x / 1000, y: item.y.p99_9 / 1e6 })),
+			  borderWidth: 1.5,
+			  borderColor: "rgb(220, 100, 100)",
+			  backgroundColor: "rgb(220, 100, 100, .8)",
+			  tension: 0.3,
+			  pointRadius: 0,
+			  yAxisID: "y2"
 			}
 			{{ end }}
 		  ]

--- a/runner/config.go
+++ b/runner/config.go
@@ -118,6 +118,7 @@ type Config struct {
 	MaxCallSendMsgSize    string            `json:"max-send-message-size" toml:"max-send-message-size" yaml:"max-send-message-size"`
 	DisableTemplateFuncs  bool              `json:"disable-template-functions" toml:"disable-template-functions" yaml:"disable-template-functions"`
 	DisableTemplateData   bool              `json:"disable-template-data" toml:"disable-template-data" yaml:"disable-template-data"`
+	P99_9                 bool              `json:"p99_9,omitempty" toml:"p99_9,omitempty" yaml:"p99_9,omitempty"`
 }
 
 func checkData(data interface{}) error {

--- a/runner/options.go
+++ b/runner/options.go
@@ -134,6 +134,7 @@ type RunConfig struct {
 	tags                          []byte
 	skipFirst                     int
 	countErrors                   bool
+	p99_9                         bool
 	recvMsgFunc                   StreamRecvMsgInterceptFunc
 	streamInterceptorProviderFunc StreamInterceptorProviderFunc
 }
@@ -713,6 +714,15 @@ func WithCountErrors(v bool) Option {
 	}
 }
 
+// WithP99_9 enables p99.9 percentile calculation
+func WithP99_9(v bool) Option {
+	return func(o *RunConfig) error {
+		o.p99_9 = v
+
+		return nil
+	}
+}
+
 // WithProtoFile specified proto file path and optionally import paths
 // We will automatically add the proto file path's directory and the current directory
 //
@@ -1219,6 +1229,7 @@ func fromConfig(cfg *Config) []Option {
 		WithConcurrencyStepDuration(time.Duration(cfg.CStepDuration)),
 		WithConcurrencyDuration(time.Duration(cfg.CMaxDuration)),
 		WithCountErrors(cfg.CountErrors),
+		WithP99_9(cfg.P99_9),
 		WithDisableTemplateFuncs(cfg.DisableTemplateFuncs),
 		WithDisableTemplateData(cfg.DisableTemplateData),
 		func(o *RunConfig) error {

--- a/runner/reporter.go
+++ b/runner/reporter.go
@@ -141,7 +141,7 @@ func (r Report) MarshalJSON() ([]byte, error) {
 
 // LatencyDistribution holds latency distribution data
 type LatencyDistribution struct {
-	Percentage int           `json:"percentage"`
+	Percentage float64       `json:"percentage"`
 	Latency    time.Duration `json:"latency"`
 }
 
@@ -224,7 +224,8 @@ func (r *Reporter) Finalize(stopReason StopReason, total time.Duration) *Report 
 		Count:          r.totalCount,
 		Total:          total,
 		ErrorDist:      r.errorDist,
-		StatusCodeDist: r.statusCodeDist}
+		StatusCodeDist: r.statusCodeDist,
+		P99_9:          r.config.p99_9}
 
 	rep.Options = Options{
 		Call:              r.config.call,
@@ -300,17 +301,32 @@ func (r *Reporter) Finalize(stopReason StopReason, total time.Duration) *Report 
 
 			rep.Fastest = time.Duration(fastestNum * float64(time.Second))
 			rep.Slowest = time.Duration(slowestNum * float64(time.Second))
-			rep.LatencyDistribution = Latencies(okLats)
+			rep.LatencyDistribution = Latencies(okLats, r.config.p99_9)
+
+			// Try to find p99.9 first, then fall back to p99, then slowestNum
 			idx := slices.IndexFunc(rep.LatencyDistribution, func(l LatencyDistribution) bool {
-				return l.Percentage == 99
+				return l.Percentage == 99.9
 			})
-			var p99 float64
-			if idx == -1 {
-				p99 = slowestNum
+			var tailPercentile float64
+			var tailPercentileValue float64
+			if idx != -1 {
+				// p99.9 is available
+				tailPercentile = rep.LatencyDistribution[idx].Latency.Seconds()
+				tailPercentileValue = 99.9
 			} else {
-				p99 = rep.LatencyDistribution[idx].Latency.Seconds()
+				// Fall back to p99
+				idx = slices.IndexFunc(rep.LatencyDistribution, func(l LatencyDistribution) bool {
+					return l.Percentage == 99
+				})
+				if idx == -1 {
+					tailPercentile = slowestNum
+					tailPercentileValue = 100
+				} else {
+					tailPercentile = rep.LatencyDistribution[idx].Latency.Seconds()
+					tailPercentileValue = 99
+				}
 			}
-			rep.Histogram = Histogram(okLats, slowestNum, fastestNum, p99)
+			rep.Histogram = Histogram(okLats, slowestNum, fastestNum, tailPercentile, tailPercentileValue)
 		}
 
 		rep.Details = r.details
@@ -319,8 +335,11 @@ func (r *Reporter) Finalize(stopReason StopReason, total time.Duration) *Report 
 	return rep
 }
 
-func Latencies(latencies []float64) []LatencyDistribution {
-	pctls := []int{10, 25, 50, 75, 90, 95, 99}
+func Latencies(latencies []float64, includeP99_9 bool) []LatencyDistribution {
+	pctls := []float64{10, 25, 50, 75, 90, 95, 99}
+	if includeP99_9 {
+		pctls = append(pctls, 99.9)
+	}
 	data := make([]float64, len(pctls))
 	lt := float64(len(latencies))
 	for i, p := range pctls {
@@ -351,14 +370,14 @@ func Latencies(latencies []float64) []LatencyDistribution {
 	return res
 }
 
-func Histogram(latencies []float64, slowest, fastest float64, p99 float64) []Bucket {
+func Histogram(latencies []float64, slowest, fastest float64, tailPercentile float64, tailPercentileValue float64) []Bucket {
 	cleanTail := len(latencies) >= 100
 	graphSlowest := slowest
 	formatMark := func(mark float64) string {
 		return fmt.Sprintf("%.3f", mark*1000)
 	}
 	if cleanTail {
-		graphSlowest = p99
+		graphSlowest = tailPercentile
 	}
 	bc := 10
 	buckets := make([]float64, bc)
@@ -394,7 +413,11 @@ func Histogram(latencies []float64, slowest, fastest float64, p99 float64) []Buc
 		}
 	}
 	if cleanTail {
-		res[bc-1].AlternativeMark = fmt.Sprintf(">=P99 [%s-%s]", formatMark(p99), formatMark(slowest))
+		percentileLabel := "P99"
+		if tailPercentileValue == 99.9 {
+			percentileLabel = "P99.9"
+		}
+		res[bc-1].AlternativeMark = fmt.Sprintf(">=%s [%s-%s]", percentileLabel, formatMark(tailPercentile), formatMark(slowest))
 	}
 	return res
 }

--- a/runner/reporter_test.go
+++ b/runner/reporter_test.go
@@ -58,3 +58,220 @@ func TestReport_CorrectDetails(t *testing.T) {
 	assert.Equal(t, ResultDetail{Error: "", Latency: cr1.duration, Status: cr1.status, Timestamp: cr1.timestamp}, report.Details[0])
 	assert.Equal(t, ResultDetail{Error: cr2.err.Error(), Latency: cr2.duration, Status: cr2.status, Timestamp: cr2.timestamp}, report.Details[1])
 }
+
+func TestLatencies_WithoutP99_9(t *testing.T) {
+	// Create 1000 latency values (0.001s to 1.0s)
+	latencies := make([]float64, 1000)
+	for i := 0; i < 1000; i++ {
+		latencies[i] = float64(i+1) / 1000.0
+	}
+
+	// Test without p99.9
+	result := Latencies(latencies, false)
+
+	// Should have 7 percentiles (10, 25, 50, 75, 90, 95, 99)
+	assert.Equal(t, 7, len(result))
+
+	// Verify percentiles are correct
+	percentiles := []float64{10, 25, 50, 75, 90, 95, 99}
+	for i, ld := range result {
+		assert.Equal(t, percentiles[i], ld.Percentage)
+	}
+
+	// Verify 99th percentile exists
+	assert.Equal(t, float64(99), result[6].Percentage)
+	// Verify p99.9 does not exist
+	for _, ld := range result {
+		assert.NotEqual(t, 99.9, ld.Percentage)
+	}
+}
+
+func TestLatencies_WithP99_9(t *testing.T) {
+	// Create 1000 latency values (0.001s to 1.0s)
+	latencies := make([]float64, 1000)
+	for i := 0; i < 1000; i++ {
+		latencies[i] = float64(i+1) / 1000.0
+	}
+
+	// Test with p99.9
+	result := Latencies(latencies, true)
+
+	// Should have 8 percentiles (10, 25, 50, 75, 90, 95, 99, 99.9)
+	assert.Equal(t, 8, len(result))
+
+	// Verify percentiles are correct
+	percentiles := []float64{10, 25, 50, 75, 90, 95, 99, 99.9}
+	for i, ld := range result {
+		assert.Equal(t, percentiles[i], ld.Percentage)
+	}
+
+	// Verify p99.9 exists and is correct
+	assert.Equal(t, 99.9, result[7].Percentage)
+	// p99.9 should be greater than p99
+	assert.True(t, result[7].Latency > result[6].Latency)
+}
+
+func TestHistogram_UsesP99Label(t *testing.T) {
+	// Create 1000 latency values
+	latencies := make([]float64, 1000)
+	for i := 0; i < 1000; i++ {
+		latencies[i] = float64(i+1) / 1000.0
+	}
+
+	slowest := latencies[len(latencies)-1]
+	fastest := latencies[0]
+	p99Value := latencies[989] // Approximately p99
+
+	// Test with p99 (tailPercentileValue = 99)
+	result := Histogram(latencies, slowest, fastest, p99Value, 99)
+
+	// Should have 10 buckets
+	assert.Equal(t, 10, len(result))
+
+	// Last bucket should have P99 label
+	assert.Contains(t, result[9].AlternativeMark, "P99")
+	assert.NotContains(t, result[9].AlternativeMark, "P99.9")
+}
+
+func TestHistogram_UsesP99_9Label(t *testing.T) {
+	// Create 1000 latency values
+	latencies := make([]float64, 1000)
+	for i := 0; i < 1000; i++ {
+		latencies[i] = float64(i+1) / 1000.0
+	}
+
+	slowest := latencies[len(latencies)-1]
+	fastest := latencies[0]
+	p99_9Value := latencies[998] // Approximately p99.9
+
+	// Test with p99.9 (tailPercentileValue = 99.9)
+	result := Histogram(latencies, slowest, fastest, p99_9Value, 99.9)
+
+	// Should have 10 buckets
+	assert.Equal(t, 10, len(result))
+
+	// Last bucket should have P99.9 label
+	assert.Contains(t, result[9].AlternativeMark, "P99.9")
+	assert.NotContains(t, result[9].AlternativeMark, ">=P99 ")
+}
+
+func TestFinalize_WithP99_9Enabled(t *testing.T) {
+	callResultsChan := make(chan *callResult)
+	config, _ := NewConfig("call", "host", WithP99_9(true))
+	reporter := newReporter(callResultsChan, config)
+
+	go reporter.Run()
+
+	// Add 1000 results with latencies from 1ms to 1000ms
+	for i := 0; i < 10000; i++ {
+		cr := callResult{
+			status:    "OK",
+			duration:  time.Duration(i+1) * time.Millisecond,
+			err:       nil,
+			timestamp: time.Now(),
+		}
+		callResultsChan <- &cr
+	}
+
+	close(callResultsChan)
+	<-reporter.done
+	report := reporter.Finalize("stop reason", time.Second*2)
+
+	// Verify p99.9 flag is set
+	assert.True(t, report.P99_9)
+
+	// Verify latency distribution includes p99.9
+	assert.Equal(t, 8, len(report.LatencyDistribution))
+
+	var p99Latency, p99_9Latency time.Duration
+	var hasP99, hasP99_9 bool
+
+	for _, ld := range report.LatencyDistribution {
+		if ld.Percentage == 99 {
+			p99Latency = ld.Latency
+			hasP99 = true
+		}
+		if ld.Percentage == 99.9 {
+			p99_9Latency = ld.Latency
+			hasP99_9 = true
+		}
+	}
+
+	assert.True(t, hasP99, "Report should include p99 in latency distribution")
+	assert.True(t, hasP99_9, "Report should include p99.9 in latency distribution")
+
+	// Verify p99.9 is greater than p99
+	assert.True(t, p99_9Latency > p99Latency, "p99.9 should be greater than p99")
+
+	// With 10000 samples, p99 should be around 9900ms and p99.9 should be around 999ms
+	assert.InDelta(t, 9900, p99Latency.Milliseconds(), 10, "p99 should be approximately 9900ms")
+	assert.InDelta(t, 9990, p99_9Latency.Milliseconds(), 8, "p99.9 should be approximately 9990ms")
+
+	// Verify histogram uses p99.9 for tail
+	assert.NotEmpty(t, report.Histogram)
+	lastBucket := report.Histogram[len(report.Histogram)-1]
+	assert.Contains(t, lastBucket.AlternativeMark, "P99.9", "Histogram tail should use P99.9 label")
+
+	// The histogram should be bounded by p99.9, not the slowest value
+	// So the last bucket mark should be close to p99.9 value, not 1000ms
+	assert.Less(t, lastBucket.Mark, 10.0, "Histogram should be bounded by p99.9, not slowest")
+}
+
+func TestFinalize_WithP99_9Disabled(t *testing.T) {
+	callResultsChan := make(chan *callResult)
+	config, _ := NewConfig("call", "host") // Default: p99_9 = false
+	reporter := newReporter(callResultsChan, config)
+
+	go reporter.Run()
+
+	// Add 1000 results with latencies from 1ms to 1000ms
+	for i := 0; i < 10000; i++ {
+		cr := callResult{
+			status:    "OK",
+			duration:  time.Duration(i+1) * time.Millisecond,
+			err:       nil,
+			timestamp: time.Now(),
+		}
+		callResultsChan <- &cr
+	}
+
+	close(callResultsChan)
+	<-reporter.done
+	report := reporter.Finalize("stop reason", time.Second*2)
+
+	// Verify p99.9 flag is not set
+	assert.False(t, report.P99_9)
+
+	// Verify latency distribution does not include p99.9
+	assert.Equal(t, 7, len(report.LatencyDistribution))
+
+	var p99Latency time.Duration
+	var hasP99, hasP99_9 bool
+
+	for _, ld := range report.LatencyDistribution {
+		if ld.Percentage == 99 {
+			p99Latency = ld.Latency
+			hasP99 = true
+		}
+		if ld.Percentage == 99.9 {
+			hasP99_9 = true
+		}
+	}
+
+	assert.True(t, hasP99, "Report should include p99 in latency distribution")
+	assert.False(t, hasP99_9, "Report should not include p99.9 in latency distribution")
+
+	// With 1000 samples, p99 should be around 9900ms
+	assert.InDelta(t, 9900, p99Latency.Milliseconds(), 10, "p99 should be approximately 9900ms")
+
+	// Verify histogram uses p99 for tail (not p99.9)
+	assert.NotEmpty(t, report.Histogram)
+	lastBucket := report.Histogram[len(report.Histogram)-1]
+	assert.Contains(t, lastBucket.AlternativeMark, "P99", "Histogram tail should use P99 label")
+	assert.NotContains(t, lastBucket.AlternativeMark, "P99.9", "Histogram tail should not use P99.9 label")
+
+	// The histogram should be bounded by p99, not p99.9
+	// So the last bucket mark should be close to p99 value (around 9.90s)
+	assert.Less(t, lastBucket.Mark, 10.0, "Histogram should be bounded by p99, not slowest")
+	assert.InDelta(t, 9.90, lastBucket.Mark, 0.02, "Last bucket should be near p99 value")
+}


### PR DESCRIPTION
- runner option to determine whether p99.9 should be calculated and displayed
  - we normally pass these in during the display portion but this happens after the latency distribution has been created from my understanding so we need to pass this in before through the runner despite only being used by the reporter
- logic to include p99.9 in latency distribution and how the histogram should be displayed if p99_9 is requested
- Unit tests for new changes